### PR TITLE
#42: implements T method for TemplatesReg and adds test for it

### DIFF
--- a/template_registry.go
+++ b/template_registry.go
@@ -93,6 +93,13 @@ func (d TemplatesReg) Add(t *Template, path []string) (err error) {
 	dir[path[prevIdx]] = t
 	return
 }
+func (d TemplatesReg) T(path []string, key string, configure func(*TemplateCfgr)) (err error) {
+	t := NewTemplate(key, configure)
+	if t == nil {
+		return fmt.Errorf("template \"%s\" with key \"%s\" somehow was not created", strings.Join(path, "/"), key)
+	}
+	return d.Add(t, path)
+}
 func (d TemplatesReg) Get(path []string) (t *Template, err error) {
 	if len(path) < 1 {
 		return nil, fmt.Errorf("wrong path \"%s\", should have at least one chunk", strings.Join(path, "/"))

--- a/template_registry_test.go
+++ b/template_registry_test.go
@@ -53,12 +53,12 @@ var _ = Describe("template registry", func() {
 			Context("when does not exist", func() {
 				It("returns dir", func() {
 					r := Reg()
-					_, err := r.Mkdirf([]string{"1"}, func(dir TemplatesReg){
+					_, err := r.Mkdirf([]string{"1"}, func(dir TemplatesReg) {
 						dir.Mkdir([]string{"1-1"})
 						dir.Mkdir([]string{"1-2"})
 					})
 					Expect(err).To(BeNil())
-					dir, err := r.Mkdirf([]string{"2"}, func(dir TemplatesReg){
+					dir, err := r.Mkdirf([]string{"2"}, func(dir TemplatesReg) {
 						dir.Mkdir([]string{"1-1"})
 						dir.Mkdir([]string{"1-2"})
 					})
@@ -69,36 +69,36 @@ var _ = Describe("template registry", func() {
 			Context("when exists", func() {
 				It("returns dir", func() {
 					r := Reg()
-					_, err := r.Mkdirf([]string{"1"}, func(dir TemplatesReg){
+					_, err := r.Mkdirf([]string{"1"}, func(dir TemplatesReg) {
 						dir.Mkdir([]string{"1-1"})
 					})
 					Expect(err).NotTo(HaveOccurred())
-					dir, err := r.Mkdirf([]string{"1"}, func(dir TemplatesReg){
+					dir, err := r.Mkdirf([]string{"1"}, func(dir TemplatesReg) {
 						dir.Mkdir([]string{"1-1"})
 					})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dir).NotTo(BeNil())
-					_, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg){
-						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg){
+					_, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg) {
+						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg) {
 							dir.Mkdir([]string{"2-1-1"})
 						})
 					})
 					Expect(err).To(BeNil())
-					dir, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg){
-						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg){
+					dir, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg) {
+						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg) {
 							dir.Mkdir([]string{"2-1-1"})
 						})
 					})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dir).NotTo(BeNil())
-					_, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg){
-						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg){
+					_, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg) {
+						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg) {
 							dir.Mkdir([]string{"2-1-2"})
 						})
 					})
 					Expect(err).To(BeNil())
-					dir, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg){
-						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg){
+					dir, err = r.Mkdirf([]string{"2"}, func(dir TemplatesReg) {
+						dir.Mkdirf([]string{"2-1"}, func(dir TemplatesReg) {
 							dir.Mkdir([]string{"2-1-2"})
 						})
 					})
@@ -142,6 +142,33 @@ var _ = Describe("template registry", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("wrong path, dir \"1-1-1\" is not found"))
 					Expect(dir).To(BeNil())
+				})
+			})
+		})
+		Describe(".T()", func() {
+			Context("when exists", func() {
+				It("fails and returns error", func() {
+					r := Reg()
+					r.Mkdir([]string{"1", "1-1", "1-1-1"})
+					err := r.T([]string{"1", "1-1", "1-1-1", "test-template"}, "test", func(t *TemplateCfgr) {
+						t.Comment("comment text")
+					})
+					Expect(err).NotTo(HaveOccurred())
+					err = r.T([]string{"1", "1-1", "1-1-1", "test-template"}, "test", func(t *TemplateCfgr) {
+						t.Comment("comment text")
+					})
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("template \"1/1-1/1-1-1/test-template\" already exists"))
+				})
+			})
+			Context("when does not exist", func() {
+				It("adds template", func() {
+					r := Reg()
+					r.Mkdir([]string{"1", "1-1", "1-1-1"})
+					err := r.T([]string{"1", "1-1", "1-1-1", "test-template"}, "test", func(t *TemplateCfgr) {
+						t.Comment("comment text")
+					})
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})


### PR DESCRIPTION
Pretty simple solution for stated problem, but definitely the neat one.
I have some second thoughts on tests for `T()` method. The thing is, now we invoke function `NewTemplate()`, which locates in file `go2html.go`, from file `template_registry_test.go`, which purpose is testing the functionality of the `template_registry.go` file. So, maybe we don't want this kind of cross-invocations.
I'm waiting to hear your thoughts on that.